### PR TITLE
set voxel_velocity for z axis consistently

### DIFF
--- a/python/main/boxes.py
+++ b/python/main/boxes.py
@@ -236,7 +236,7 @@ class SimulationBox(Box):
         super(SimulationBox, self).__init__(self.spectra_instance.red, H0, self.spectra_instance.OmegaM, nskewers)
         self.voxel_velocities['x'] = (self.spectra_instance.vmax / self._n_samp['x']) * (u.km / u.s)
         self.voxel_velocities['y'] = (self.spectra_instance.vmax / self._n_samp['y']) * (u.km / u.s)
-        self.voxel_velocities['z'] = self.spectra_instance.dvbin * (u.km / u.s)
+        self.voxel_velocities['z'] = (self.spectra_instance.vmax / self._n_samp['z']) * (u.km / u.s)
         print("Size of voxels in velocity units =", self.voxel_velocities)
         for i in ['x','y','z']:
             #Comoving units


### PR DESCRIPTION
Addresses issue #5 . 

Note that fake_spectra has since fixed this bug, and spectra.dvbin does store the true value of pixel width, but I think it is still more consistent to use n_samps to set this. 