### PR TITLE
fixed mu computation, k was fine

### DIFF
--- a/python/main/boxes.py
+++ b/python/main/boxes.py
@@ -69,8 +69,9 @@ class Box(object):
         y = self.k_i('y')[np.newaxis, :, np.newaxis]
         z = self.k_i('z')[np.newaxis, np.newaxis, :]
         k = np.sqrt(x**2 + y**2 + z**2)
-        k[k == 0.] = np.nan
-        return z / k
+        mu = z / k 
+        mu[k == 0.] = np.nan
+        return mu
 
     #Configuration space coordinates
     def r_i(self,i):


### PR DESCRIPTION
the code was setting 
k[k==0.]=np.nan
while I guess it meant to do
mu[k==0.]=np.nan
since there is nothing wrong with k=0.

